### PR TITLE
Multiple nested configuration blocks of the same type are merged into a list

### DIFF
--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -48,7 +48,7 @@ class HclParser(object):
     #
     # Yacc parser section
     #
-    def objectlist_flat(self, lt):
+    def objectlist_flat(self, lt, replace):
         '''
             Similar to the dict constructor, but handles dups
             
@@ -63,24 +63,30 @@ class HclParser(object):
         d = {}
         
         for k,v in lt:
-            if isinstance(v, dict):
-                dd = d.setdefault(k, {})
-                for kk, vv in iteritems(v):
-                    if kk in dd.keys():
-                        for k2, v2 in iteritems(vv):
-                            dd[kk][k2] = v2
-                    else:
-                        dd[kk] = vv
+            if k in d.keys() and not replace:
+                if type(d[k]) is list:
+                    d[k].append(v)
+                else:
+                    d[k] = [d[k],v]
             else:
-                d[k] = v
-            
+                if isinstance(v, dict):
+                    dd = d.setdefault(k, {})
+                    for kk, vv in iteritems(v):
+                        if kk in dd.keys():
+                            for k2, v2 in iteritems(vv):
+                                dd[kk][k2] = v2
+                        else:
+                            dd[kk] = vv
+                else:
+                    d[k] = v
+
         return d
     
     def p_top(self, p):
         "top : objectlist"
         if DEBUG:
             self.print_p(p)
-        p[0] = self.objectlist_flat(p[1])
+        p[0] = self.objectlist_flat(p[1],True)
     
     
     def p_objectlist_0(self, p):
@@ -100,7 +106,7 @@ class HclParser(object):
         "object : LEFTBRACE objectlist RIGHTBRACE"
         if DEBUG:
             self.print_p(p)
-        p[0] = self.objectlist_flat(p[2])
+        p[0] = self.objectlist_flat(p[2],False)
         
     def p_object_1(self, p):
         "object : LEFTBRACE RIGHTBRACE"

--- a/tests/fixtures/structure_list_deep.hcl
+++ b/tests/fixtures/structure_list_deep.hcl
@@ -1,0 +1,17 @@
+bar "foo" {
+
+    name = "terraform_example"
+
+    ingress {
+        from_port = 22
+    }
+
+    ingress {
+        from_port = 80
+    }
+
+    ingress {
+        from_port = 51
+    }
+
+}

--- a/tests/fixtures/structure_list_deep.json
+++ b/tests/fixtures/structure_list_deep.json
@@ -8,6 +8,9 @@
                 },
                 {
                     "from_port": 80
+                },
+                {
+                    "from_port": 51
                 }
             ]
         }

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -32,7 +32,8 @@ FIXTURES = [
     #'structure_list_deep.json'
     ('structure_multi.hcl', 'structure_multi.json', None),
     ('structure_three_tiers.hcl', 'structure_three_tiers.json', None),
-    ('terraform_heroku.hcl', 'terraform_heroku.json', None)
+    ('terraform_heroku.hcl', 'terraform_heroku.json', None),
+    ('structure_list_deep.hcl','structure_list_deep.json', None)
 ]
 
 


### PR DESCRIPTION
I was having issues parsing Terraform config files that have multiple configuration blocks with the same name(egress rules in **aws_security_group**, block devices in **aws_instance**).

I believe it's the same issue as https://github.com/virtuald/pyhcl/issues/7

```
Traceback (most recent call last):
  File "/usr/local/bin/hcltool", line 45, in <module>
    main()
  File "/usr/local/bin/hcltool", line 35, in main
    obj = hcl.load(infile)
  File "/usr/local/lib/python2.7/site-packages/hcl/api.py", line 51, in load
    return loads(fp.read())
  File "/usr/local/lib/python2.7/site-packages/hcl/api.py", line 62, in loads
    return HclParser().parse(s)
  File "/usr/local/lib/python2.7/site-packages/hcl/parser.py", line 294, in parse
    return self.yacc.parse(s, lexer=Lexer())
  File "/usr/local/lib/python2.7/site-packages/ply/yacc.py", line 265, in parse
    return self.parseopt_notrack(input,lexer,debug,tracking,tokenfunc)
  File "/usr/local/lib/python2.7/site-packages/ply/yacc.py", line 971, in parseopt_notrack
    p.callable(pslice)
  File "/usr/local/lib/python2.7/site-packages/hcl/parser.py", line 110, in p_object_0
    p[0] = self.objectlist_flat(p[2])
  File "/usr/local/lib/python2.7/site-packages/hcl/parser.py", line 73, in objectlist_flat
    for k2, v2 in iteritems(vv):
  File "/usr/local/lib/python2.7/site-packages/hcl/parser.py", line 29, in iteritems
    return iter(d.iteritems())
AttributeError: 'int' object has no attribute 'iteritems'
```

This PR allows the following configuration to be parsed without any errors.

```
resource "aws_security_group" "foo" {
  name        = "foo"
  description = "bar"

  # SSH
  ingress {
    from_port   = "22"
    to_port     = "22"
    protocol    = "tcp"
  }

  # Web
  ingress {
    from_port   = "8080"
    to_port     = "8080"
    protocol    = "tcp"
  }
}

```
JSON output with `hcltool`
```
{
    "resource": {
        "aws_security_group": {
            "foo": {
                "description": "bar",
                "ingress": [
                    {
                        "from_port": "22",
                        "protocol": "tcp",
                        "to_port": "22"
                    },
                    {
                        "from_port": "8080",
                        "protocol": "tcp",
                        "to_port": "8080"
                    }
                ],
                "name": "foo"
            }
        }
    }
}
```

Running `terraform plan` against this JSON results in a valid plan

```
+ aws_security_group.foo
    description:                          "" => "bar"
    egress.#:                             "" => "<computed>"
    ingress.#:                            "" => "2"
    ingress.3457728489.cidr_blocks.#:     "" => "0"
    ingress.3457728489.from_port:         "" => "22"
    ingress.3457728489.protocol:          "" => "tcp"
    ingress.3457728489.security_groups.#: "" => "0"
    ingress.3457728489.self:              "" => "0"
    ingress.3457728489.to_port:           "" => "22"
    ingress.720993836.cidr_blocks.#:      "" => "0"
    ingress.720993836.from_port:          "" => "8080"
    ingress.720993836.protocol:           "" => "tcp"
    ingress.720993836.security_groups.#:  "" => "0"
    ingress.720993836.self:               "" => "0"
    ingress.720993836.to_port:            "" => "8080"
    name:                                 "" => "foo"
    owner_id:                             "" => "<computed>"
    vpc_id:                               "" => "<computed>"
```