### PR TITLE
hide warnings

### DIFF
--- a/src/hcl/lexer.py
+++ b/src/hcl/lexer.py
@@ -219,7 +219,7 @@ class Lexer(object):
             _raise_error(t)
 
     def __init__(self):
-        self.lex = lex.lex(module=self, debug=False, reflags=(re.UNICODE | re.MULTILINE))
+        self.lex = lex.lex(module=self, debug=False, reflags=(re.UNICODE | re.MULTILINE), errorlog=lex.NullLogger())
 
     def input(self, s):
         return self.lex.input(s)


### PR DESCRIPTION
resolves https://github.com/virtuald/pyhcl/issues/19

If it turns out it's useful to know about these warnings, this could be changed so that it's configurable, but I don't think that's necessary.