### PR TITLE
Allow lists of objects in parser

### DIFF
--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -211,6 +211,7 @@ class HclParser(object):
     def p_listitem(self, p):
         '''
         listitem : number
+                 | object
                  | STRING
         '''
         if DEBUG:

--- a/tests/lex-fixtures/list_of_maps.hcl
+++ b/tests/lex-fixtures/list_of_maps.hcl
@@ -1,0 +1,4 @@
+foo = [
+  {somekey1 = "someval1"},
+  {somekey2 = "someval2", someextrakey = "someextraval"},
+]

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -51,6 +51,17 @@ LEX_FIXTURES = [
         ],
     ),
     (
+        "list_of_maps.hcl",
+        [
+            "IDENTIFIER", "EQUAL", "LEFTBRACKET",
+            "LEFTBRACE", "IDENTIFIER", "EQUAL", "STRING", "RIGHTBRACE",
+            "COMMA",
+            "LEFTBRACE", "IDENTIFIER", "EQUAL", "STRING", "COMMA",
+            "IDENTIFIER", "EQUAL", "STRING", "RIGHTBRACE", "COMMA",
+            "RIGHTBRACKET", None,
+        ],
+    ),
+    (
         "structure_basic.hcl",
         [
             "IDENTIFIER", "LEFTBRACE",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,6 +25,10 @@ PARSE_FIXTURES = [
         False,
     ),
     (
+        "list_of_maps.hcl",
+        False,
+    ),
+    (
         "multiple.hcl",
         False,
     ),
@@ -46,7 +50,7 @@ PARSE_FIXTURES = [
     ),
     (
         "assign_deep.hcl",
-        True,
+        False,
     ),
     (
         "types.hcl",


### PR DESCRIPTION
#29 
Support for lists of maps/objects was added to the golang HCL parser in
June 2016, and the test case list_of_maps.hcl was added for it. Add
support to the PyHCL parser, lift this test case, and also enable test
case assign_deep.hcl, which can now be expected to pass.