### PR TITLE
allow multiple providers

### DIFF
--- a/src/hcl/api.py
+++ b/src/hcl/api.py
@@ -1,4 +1,3 @@
-
 import json
 from .parser import HclParser
 

--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -1,4 +1,3 @@
-
 from os.path import abspath, dirname, exists, join
 import sys
 

--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -59,7 +59,7 @@ class HclParser(object):
         'EPLUS',
         'EMINUS',
     )
-
+    allowedDups = set(["provider"])
     #
     # Yacc parser section
     #
@@ -106,8 +106,8 @@ class HclParser(object):
         "top : objectlist"
         if DEBUG:
             self.print_p(p)
-        withoutIt = filter(lambda x: x[0] != "provider", p[1])
-        withIt = filter(lambda x: x[0] == "provider", p[1])
+        withoutIt = filter(lambda x: x[0] not in self.allowedDups, p[1])
+        withIt = filter(lambda x: x[0] in self.allowedDups, p[1])
         unique = self.objectlist_flat(withoutIt, True)
         dup = self.objectlist_flat(withIt, False)
         dup.update(unique)

--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -7,7 +7,7 @@ from ply import lex, yacc
 
 import inspect
 
-DEBUG = True
+DEBUG = False
 
 # When using something like pyinstaller, the __file__ attribute isn't actually
 # set correctly, so the parse file isn't able to be saved anywhere sensible.

--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -105,10 +105,10 @@ class HclParser(object):
         "top : objectlist"
         if DEBUG:
             self.print_p(p)
-        withoutIt = filter(lambda x: x[0] not in self.allowedDups, p[1])
-        withIt = filter(lambda x: x[0] in self.allowedDups, p[1])
-        unique = self.objectlist_flat(withoutIt, True)
-        dup = self.objectlist_flat(withIt, False)
+        withoutDupes = filter(lambda x: x[0] not in self.allowedDups, p[1])
+        withDupes = filter(lambda x: x[0] in self.allowedDups, p[1])
+        unique = self.objectlist_flat(withoutDupes, True)
+        dup = self.objectlist_flat(withDupes, False)
         dup.update(unique)
         p[0] = dup
 

--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -7,7 +7,7 @@ from ply import lex, yacc
 
 import inspect
 
-DEBUG = False
+DEBUG = True
 
 # When using something like pyinstaller, the __file__ attribute isn't actually
 # set correctly, so the parse file isn't able to be saved anywhere sensible.
@@ -66,13 +66,13 @@ class HclParser(object):
     def objectlist_flat(self, lt, replace):
         '''
             Similar to the dict constructor, but handles dups
-            
+
             HCL is unclear on what one should do when duplicate keys are
             encountered. These comments aren't clear either:
-            
+
             from decoder.go: if we're at the root or we're directly within
                              a list, decode into dicts, otherwise lists
-                
+
             from object.go: there's a flattened list structure
         '''
         d = {}
@@ -106,7 +106,12 @@ class HclParser(object):
         "top : objectlist"
         if DEBUG:
             self.print_p(p)
-        p[0] = self.objectlist_flat(p[1], True)
+        withoutIt = filter(lambda x: x[0] != "provider", p[1])
+        withIt = filter(lambda x: x[0] == "provider", p[1])
+        unique = self.objectlist_flat(withoutIt, True)
+        dup = self.objectlist_flat(withIt, False)
+        dup.update(unique)
+        p[0] = dup
 
     def p_objectlist_0(self, p):
         "objectlist : objectitem"

--- a/tests/fixtures/provider.hcl
+++ b/tests/fixtures/provider.hcl
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "${var.active_region}"
+  version = "~> 1.28.0"
+}
+ 
+provider "aws" {
+  region  = "${var.active_region-2}"
+  version = "~> 1.28.0"
+  alias = "dr"
+}

--- a/tests/fixtures/provider.json
+++ b/tests/fixtures/provider.json
@@ -1,0 +1,15 @@
+{
+  "provider": {
+    "aws": [
+      {
+        "region": "${var.active_region-2}",
+        "version": "~> 1.28.0"
+      },
+      {
+        "alias": "dr",
+        "region": "${var.active_region-2}",
+        "version": "~> 1.28.0"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/provider.json
+++ b/tests/fixtures/provider.json
@@ -1,15 +1,16 @@
 {
-  "provider": {
-    "aws": [
-      {
-        "region": "${var.active_region-2}",
+  "provider": [
+    {
+      "aws": {
+        "region": "${var.active_region}",
         "version": "~> 1.28.0"
-      },
-      {
+      }
+    },{
+      "aws": {
         "alias": "dr",
         "region": "${var.active_region-2}",
         "version": "~> 1.28.0"
       }
-    ]
-  }
+    }
+  ]
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-pip install -e .
-python -m coverage run --source hcl -m pytest tests
+pip3 install -e .
+python3 -m coverage run --source hcl -m pytest tests
 if [ "$?" != "0" ]; then
 	exit 1
 fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-pip3 install -e .
-python3 -m coverage run --source hcl -m pytest tests
+pip install -e .
+python -m coverage run --source hcl -m pytest tests
 if [ "$?" != "0" ]; then
 	exit 1
 fi

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -15,6 +15,7 @@ FIXTURE_DIR = join(dirname(__file__), 'fixtures')
 FIXTURES = [
     ('array_comment.hcl', 'array_comment.json', None),
     ('basic.hcl', 'basic.json', None),
+    ('provider.hcl', 'provider.json', None),
     ('basic_squish.hcl', None, {'foo': 'bar', 'bar': '${file("bing/bong.txt")}', 'foo-bar':"baz"}),
     ('decode_policy.hcl', 'decode_policy.json', None),
     ('decode_tf_variable.hcl', 'decode_tf_variable.json', None),


### PR DESCRIPTION
this pr will allow multiple providers in the same "top".  this is supposed by terraform.
below is a simple example showing the multiple providers.
im not happy about the hacky hack i put in there, if you reject ill figure out how to map specific object types via the token tree.
[Archive.zip](https://github.com/virtuald/pyhcl/files/2563998/Archive.zip)

