### PR TITLE
Errors when building wheel (Added `pyproject.toml`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["ply"]
+requires = ["setuptools", "wheel", "ply"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["ply"]


### PR DESCRIPTION
The `ply` package is used in setup.py
This breaks the build on CI

https://www.python.org/dev/peps/pep-0518/

```bash
pip wheel pyhcl
Collecting pyhcl
Collecting ply==3.10 (from pyhcl)
Skipping ply, due to already being wheel.
Building wheels for collected packages: pyhcl
  Running setup.py bdist_wheel for pyhcl ... error
  Complete output from command /Users/username/projects/config-generator/.direnv/python-3.6.6/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-np3aaz52/pyhcl/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-yckdf6gi:
  running bdist_wheel
  running build
  running build_py
  Generating parse table...
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-np3aaz52/pyhcl/setup.py", line 96, in <module>
      "Topic :: Text Processing"
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/dist.py", line 955, in run_commands
      self.run_command(cmd)
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/Users/username/projects/config-generator/.direnv/python-3.6.6/lib/python3.6/site-packages/wheel/bdist_wheel.py", line 188, in run
      self.run_command('build')
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/command/build.py", line 135, in run
      self.run_command(cmd_name)
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-np3aaz52/pyhcl/setup.py", line 37, in run
      self.execute(_pre_install, (), msg="Generating parse table...")
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/cmd.py", line 335, in execute
      util.execute(func, args, msg, dry_run=self.dry_run)
    File "/Users/username/.pyenv/versions/3.6.6/lib/python3.6/distutils/util.py", line 301, in execute
      func(*args)
    File "/private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-np3aaz52/pyhcl/setup.py", line 30, in _pre_install
      import hcl
    File "/private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-np3aaz52/pyhcl/src/hcl/__init__.py", line 1, in <module>
      from .api import dumps, load, loads
    File "/private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-np3aaz52/pyhcl/src/hcl/api.py", line 3, in <module>
      from .parser import HclParser
    File "/private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-np3aaz52/pyhcl/src/hcl/parser.py", line 5, in <module>
      from .lexer import Lexer
    File "/private/var/folders/hn/l3tn34716cg1h3yrt4tgnl1h0000gp/T/pip-wheel-np3aaz52/pyhcl/src/hcl/lexer.py", line 3, in <module>
      import ply.lex as lex
  ModuleNotFoundError: No module named 'ply'

  ----------------------------------------
  Failed building wheel for pyhcl
  Running setup.py clean for pyhcl
Failed to build pyhcl
ERROR: Failed to build one or more wheels
```