### PR TITLE
Skip parse table if ply not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,12 @@ def _pre_install():
 
 class build_py(_build_py):
     def run(self):
-        self.execute(_pre_install, (), msg="Generating parse table...")
+        try:
+            import ply
+        except ImportError:
+            print("skipping parse table")
+        else:
+            self.execute(_pre_install, (), msg="generating parse table...")
         _build_py.run(self)
 
 


### PR DESCRIPTION
When I try to install pyhcl in a fresh environment I get a big red error. It still works, but it's disconcerting and makes it look broken. See #49

```
$ pip install --no-cache pyhcl
Collecting pyhcl
  Downloading https://files.pythonhosted.org/packages/8c/90/411f698550155532a1375d0367da08c2d0ecc922d4c0362bd4236893238b/pyhcl-0.3.12.tar.gz
Collecting ply<4,>=3.8 (from pyhcl)
  Downloading https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl (49kB)
     |████████████████████████████████| 51kB 1.7MB/s 
Building wheels for collected packages: pyhcl
  Building wheel for pyhcl (setup.py) ... error
  ERROR: Complete output from command /tmp/ply-error/.direnv/python-3.6.7/bin/python3 -u -c 'import setuptools, tokenize;__file__='"'"'/tmp/pip-install-x4mqfh1l/pyhcl/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-xa8xkq8v --python-tag cp36:
  ERROR: running bdist_wheel
  running build
  running build_py
  Generating parse table...
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-install-x4mqfh1l/pyhcl/setup.py", line 101, in <module>
      "Topic :: Text Processing",
    File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/tmp/ply-error/.direnv/python-3.6.7/lib/python3.6/site-packages/wheel/bdist_wheel.py", line 192, in run
      self.run_command('build')
    File "/usr/lib/python3.6/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/usr/lib/python3.6/distutils/command/build.py", line 135, in run
      self.run_command(cmd_name)
    File "/usr/lib/python3.6/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/tmp/pip-install-x4mqfh1l/pyhcl/setup.py", line 39, in run
      self.execute(_pre_install, (), msg="Generating parse table...")
    File "/usr/lib/python3.6/distutils/cmd.py", line 335, in execute
      util.execute(func, args, msg, dry_run=self.dry_run)
    File "/usr/lib/python3.6/distutils/util.py", line 301, in execute
      func(*args)
    File "/tmp/pip-install-x4mqfh1l/pyhcl/setup.py", line 31, in _pre_install
      import hcl
    File "/tmp/pip-install-x4mqfh1l/pyhcl/src/hcl/__init__.py", line 1, in <module>
      from .api import dumps, load, loads
    File "/tmp/pip-install-x4mqfh1l/pyhcl/src/hcl/api.py", line 2, in <module>
      from .parser import HclParser
    File "/tmp/pip-install-x4mqfh1l/pyhcl/src/hcl/parser.py", line 4, in <module>
      from .lexer import Lexer
    File "/tmp/pip-install-x4mqfh1l/pyhcl/src/hcl/lexer.py", line 3, in <module>
      import ply.lex as lex
  ModuleNotFoundError: No module named 'ply'
  ----------------------------------------
  ERROR: Failed building wheel for pyhcl
  Running setup.py clean for pyhcl
Failed to build pyhcl
Installing collected packages: ply, pyhcl
  Running setup.py install for pyhcl ... done
Successfully installed ply-3.11 pyhcl-0.3.12
```

#46 looks like it *should* fix it. Perhaps `include pyproject.toml` needs to be included in `MANIFEST.in` for it to work in pip, but it's hard to test that without publishing it to PyPI.

So I looked at skipping the build step when we know for sure that it will fail.

Before my change:

```
$ python setup.py build_py
running build_py
Generating parse table...
Traceback (most recent call last):
  File "setup.py", line 101, in <module>
    "Topic :: Text Processing",
  File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 39, in run
    self.execute(_pre_install, (), msg="Generating parse table...")
  File "/usr/lib/python3.6/distutils/cmd.py", line 335, in execute
    util.execute(func, args, msg, dry_run=self.dry_run)
  File "/usr/lib/python3.6/distutils/util.py", line 301, in execute
    func(*args)
  File "setup.py", line 31, in _pre_install
    import hcl
  File "/home/ray/github/pyhcl/raymondbutcher/pyhcl/src/hcl/__init__.py", line 1, in <module>
    from .api import dumps, load, loads
  File "/home/ray/github/pyhcl/raymondbutcher/pyhcl/src/hcl/api.py", line 2, in <module>
    from .parser import HclParser
  File "/home/ray/github/pyhcl/raymondbutcher/pyhcl/src/hcl/parser.py", line 4, in <module>
    from .lexer import Lexer
  File "/home/ray/github/pyhcl/raymondbutcher/pyhcl/src/hcl/lexer.py", line 3, in <module>
    import ply.lex as lex
ModuleNotFoundError: No module named 'ply'
```

After my change:

```
$ python setup.py build_py
running build_py
skipping parse table
creating build/lib
creating build/lib/hcl
copying src/hcl/lexer.py -> build/lib/hcl
copying src/hcl/version.py -> build/lib/hcl
copying src/hcl/api.py -> build/lib/hcl
copying src/hcl/parser.py -> build/lib/hcl
copying src/hcl/__init__.py -> build/lib/hcl
running egg_info
writing src/pyhcl.egg-info/PKG-INFO
writing dependency_links to src/pyhcl.egg-info/dependency_links.txt
writing requirements to src/pyhcl.egg-info/requires.txt
writing top-level names to src/pyhcl.egg-info/top_level.txt
reading manifest file 'src/pyhcl.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'src/hcl/parsetab.dat'
writing manifest file 'src/pyhcl.egg-info/SOURCES.txt'
```