### PR TITLE
Added missing "hcl.ply" module to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     url='https://github.com/virtuald/pyhcl',
     package_dir={'': 'src'},
     package_data={'hcl': ['src/hcl/parsetab.dat']},
-    packages=['hcl'],
+    packages=['hcl','hcl.ply'],
     scripts=["scripts/hcltool"],
     include_package_data=True,
     setup_requires=install_requires,


### PR DESCRIPTION
I /just/ noticed this small oversight in my last commit. Without this update the vendored `ply` module will not actually be shipped when you cut a dist.