### PR TITLE
Make debug mode configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,14 @@ To run the tests::
 
     pip install -r testing-requirements.txt
     tests/run_tests.sh
+    
+Debug Mode
+----------
+
+To enable debug mode:
+
+    import hcl
+    hcl.parser.DEBUG = True
 
 Authors
 =======

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ To run the tests::
 Debug Mode
 ----------
 
-To enable debug mode:
+To enable debug mode::
 
     import hcl
     hcl.parser.DEBUG = True

--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -629,5 +629,5 @@ class HclParser(object):
 
     def parse(self, s, export_comments=None):
         return self.yacc.parse(
-            s, lexer=Lexer(export_comments=export_comments), debug=True
+            s, lexer=Lexer(export_comments=export_comments), debug=DEBUG
         )


### PR DESCRIPTION
In the latest version debug is hard-coded to on. This merge will call the parser using the global DEBUG variable, which is configurable by toggling hcl.parser.DEBUG to True or False.