### PR TITLE
Remove unused COMMAEND token

### DIFF
--- a/src/hcl/parser.py
+++ b/src/hcl/parser.py
@@ -49,7 +49,6 @@ class HclParser(object):
         'FLOAT',
         'NUMBER',
         'COMMA',
-        'COMMAEND',
         'COMMENT',
         'MULTICOMMENT',
         'IDENTIFIER',


### PR DESCRIPTION
This token has been defined for quite a while, but there is now a warning about it being unused (which it is). I'm assuming the behavior change came from pulling in the latest yacc parser, which now correctly alerts.

Fixes: #69