### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,13 @@
 from __future__ import print_function
 
 from os.path import abspath, dirname, join, exists
-from distutils.core import setup
 
 try:
     from setuptools.command.build_py import build_py as _build_py
 except ImportError:
     from distutils.command.build_py import build_py as _build_py
+
+from distutils.core import setup
 
 import os
 import sys


### PR DESCRIPTION
setuptools 60 uses its own bunlded version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This is to prepare for Python 3.12, which will drop distutils.